### PR TITLE
fix: hasSimilarPt check keeps match once found

### DIFF
--- a/plugins/L1CaloEGammaSingleAnalyzer.cc
+++ b/plugins/L1CaloEGammaSingleAnalyzer.cc
@@ -843,8 +843,9 @@ void L1TCaloEGammaSingleAnalyzer::analyze(const Event& evt, const EventSetup& iS
       if (reco::deltaR(newl1eg.eta, newl1eg.phi, gctCluster.p4.Eta(), gctCluster.p4.Phi()) < 0.05) {
         deltaRmatched = true;
         // If pT difference is greater than 20%, throw an error
-        hasSimilarPt = ( (abs(newl1eg.pt - gctCluster.p4.Pt()) / gctCluster.p4.Pt()) < 0.20);
-        continue;
+        if (!hasSimilarPt){
+          hasSimilarPt = ( (abs(newl1eg.pt - gctCluster.p4.Pt()) / gctCluster.p4.Pt()) < 0.20);
+        }
       } 
     }
     if (!deltaRmatched) {


### PR DESCRIPTION
The `hasSimilarPt` test in L1CaloEGammaSingleAnalyzer.cc had an issue where it would reach a gctCluster/L1 eg match as `hasSimilarPt=true`, then consider an incorrect match, rewriting this to be `hasSimilarPt=false`. This fix uses an if statement so that `hasSimilarPt` is not reverted once set to `true`, and all match candidates in the loop are considered.